### PR TITLE
docs: document mermaid edge label rendering limitation

### DIFF
--- a/docs/modules/06-domain.md
+++ b/docs/modules/06-domain.md
@@ -29,6 +29,7 @@ Master patterns for common software development scenarios: refactoring, architec
 
 ### Refactoring Workflow
 
+<!-- Note: Edge labels may render with gray backgrounds on GitHub - this is a known limitation -->
 ```mermaid
 flowchart LR
     UNDERSTAND["🔍 Understand"]


### PR DESCRIPTION
## Summary
- Add HTML comment noting GitHub's mermaid edge label rendering limitation

## Test plan
- [x] Comment is hidden in rendered markdown
- [x] Documents known issue for future maintainers

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)