### PR TITLE
Fix resume/sessions commands

### DIFF
--- a/docs/modules/01-getting-started.md
+++ b/docs/modules/01-getting-started.md
@@ -148,7 +148,7 @@ codex --sandbox read-only
 ```bash
 codex                           # Interactive TUI in current directory
 codex --cd ~/other-project      # Start in different directory
-codex resume                    # Continue last session
+codex resume --last             # Continue last session
 codex exec "prompt"             # Non-interactive, single response
 ```
 
@@ -250,7 +250,8 @@ API-focused content (internals, custom integrations) is in Modules 8-9 for when 
 ```bash
 codex                    # Start interactive session
 codex exec "prompt"      # Non-interactive
-codex resume             # Continue last session
+codex resume --last      # Continue last session
+codex resume             # Pick from recent sessions
 ```
 
 ### Safety Flags


### PR DESCRIPTION
## Summary
- Replace `codex --resume` with `codex resume`
- Remove nonexistent `codex sessions list` command

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)