### PR TITLE
Soften Git repo required statements

### DIFF
--- a/docs/training/codex-cli-hands-on/02-setup.md
+++ b/docs/training/codex-cli-hands-on/02-setup.md
@@ -4,7 +4,7 @@ Prerequisites:
 - Node 18+ or Homebrew access; shell with `curl`/`zsh`/`bash`.
 - ChatGPT account with Codex access (preferred) or OpenAI API key as fallback.
 - A small practice repo you can modify safely (e.g., a toy script).
-- **Important:** Codex CLI requires running inside a Git repository to track changes and prevent destructive operations.
+- **Recommended:** Run inside a Git repository for change tracking and safety. Use `--skip-git-repo-check` to run outside a repo if needed.
 
 Install Codex CLI (see [official README](https://github.com/openai/codex#readme)):
 - `npm install -g @openai/codex` or `brew install --cask codex`

--- a/docs/training/codex-cli-hands-on/03-cli-labs.md
+++ b/docs/training/codex-cli-hands-on/03-cli-labs.md
@@ -2,7 +2,7 @@
 
 Use a disposable repo. Keep approvals visible so learners see the safety loop. Each lab lists a goal, steps, and checks.
 
-> **Note:** Codex CLI requires running inside a Git repository. Ensure your practice repo is initialized with `git init` before starting labs.
+> **Note:** Running inside a Git repository is recommended for change tracking. Use `git init` to initialize, or `--skip-git-repo-check` to run outside a repo.
 
 ## Lab 1: Orientation Prompt (interactive TUI)
 Goal: Verify Codex can read files and respond with context.  


### PR DESCRIPTION
## Summary
- Change "requires" to "recommended" for Git repository
- Mention `--skip-git-repo-check` flag for running outside repos

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)